### PR TITLE
feat(dew.go): return the custom validate error wrapped with the ErrVa…

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
           go-version: 1.20.x
 
       - name: Cache Go modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/dew.go
+++ b/dew.go
@@ -45,7 +45,7 @@ func DispatchMulti(ctx context.Context, actions ...CommandHandler[Action]) error
 	return mux.mHandlers[mDispatch](rctx, func(ctx Context) error {
 		for _, action := range actions {
 			if err := action.Command().(Action).Validate(ctx.Context()); err != nil {
-				return fmt.Errorf("%w: %v", ErrValidationFailed, err)
+				return fmt.Errorf("%w: %w", ErrValidationFailed, err)
 			}
 			if err := action.Mux().dispatch(ACTION, ctx, action); err != nil {
 				return err


### PR DESCRIPTION
@MohammadBnei
feat(dew.go): return the custom validate error wrapped with the ErrValidationFailed

I want to be able to use errors.Is with the returned validation error from the commands. The current implementation uses a %v in the validate error wrapping, removing the error's informations. Multiple error wrapping is possible since go 1.20 (https://go.dev/doc/go1.20#errors)